### PR TITLE
fix: deprecated _init

### DIFF
--- a/usr/libxt_ipaddr.c
+++ b/usr/libxt_ipaddr.c
@@ -251,7 +251,11 @@ static struct xtables_match ipaddr_mt6_reg = {
 	.extra_opts    = ipaddr_mt_opts,
 };
 
-static void _init(void)
+/*
+	Use of _init and _fini is deprecated.
+	See : http://www.faqs.org/docs/Linux-HOWTO/Program-Library-HOWTO.html#INIT-AND-CLEANUP
+*/
+static void __attribute__((constructor)) _init(void)
 {
 	xtables_register_match(&ipaddr_mt_reg);
 	xtables_register_match(&ipaddr_mt6_reg);


### PR DESCRIPTION
Thanks for your module, it was a great help for me. The `_init` declaration is deprecated now, the module doesn't execute the init function, I had to debug this for very long ! I hope this PR will help others having the same problem.